### PR TITLE
Improve datagen advice, add actions feature

### DIFF
--- a/.github/workflows/sendpreview.yml
+++ b/.github/workflows/sendpreview.yml
@@ -4,6 +4,7 @@ jobs:
     build-and-send:
         name: Build Jar and send to Discord
         runs-on: ubuntu-20.04
+        if: "!contains(github.event.head_commit.message, 'ci skip')"
         steps:
             -   uses: actions/checkout@master
                 with:

--- a/README.md
+++ b/README.md
@@ -11,4 +11,9 @@
 4. Have somebody review it, and merge
 
 ### Datagen (if runData fails):
-Can occasionally have some bugs, see [here](src/main/java/com/railwayteam/railways/mixin/README.md) for more info.
+Can occasionally have some bugs, see [here](src/main/java/com/railwayteam/railways/mixin/README.md) for more info. (There should be an upstream Create fix for this, but that is not yet in any 1.18 release, and so we can't take advantage of it.)
+
+### Commit Tricks:
+- Include `ci skip` in your commit message to skip the automatic preview build
+you can use this for example if the change you made is very minor, and not worth
+a preview, or if you are just fixing a typo in the README, etc.

--- a/src/main/java/com/railwayteam/railways/mixin/README.md
+++ b/src/main/java/com/railwayteam/railways/mixin/README.md
@@ -1,7 +1,11 @@
 # IMPORTANT:
-You have to be very careful what Registrate-involved classes
-you import from Create. They can cause data generators to fail.
-If possible, `import static` just the values you need.
-
-*Also, you can delete `src/generated/resources/data` and re-run `runData`,
-this tends to fix it*
+~~You have to be very careful what Registrate-involved classes
+you import from Create. They can cause data generators to fail.~~
+The above is probably wrong. It is most likely the fact that we
+reference `AllTags` classes that causes the issue. I don't know
+if the following advice is therefore still applicable.
+>If possible, `import static` just the values you need.
+> 
+>*Also, you can delete `src/generated/resources/data` and re-run `runData`,
+this tends to fix it* **Make sure to add `src/generated/resources/data` back
+> into git before sending in a commit if you use this trick.**


### PR DESCRIPTION
It probably won't work on this commit, because this commit has to update the action, but let's try anyway: (ci skip)