### PR TITLE
fix datagen for pickaxe and track recipe

### DIFF
--- a/common/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/generated/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -24,61 +24,229 @@
     "railways:smokestack_streamlined",
     "railways:smokestack_woodburner",
     "railways:smokestack_diesel",
-    "railways:track_hexcasting_edified",
-    "railways:track_byg_aspen",
-    "railways:track_byg_baobab",
-    "railways:track_byg_blue_enchanted",
-    "railways:track_byg_bulbis",
-    "railways:track_byg_cherry",
-    "railways:track_byg_cika",
-    "railways:track_byg_cypress",
-    "railways:track_byg_ebony",
-    "railways:track_byg_embur",
-    "railways:track_byg_ether",
-    "railways:track_byg_fir",
-    "railways:track_byg_green_enchanted",
-    "railways:track_byg_holly",
-    "railways:track_byg_imparius",
-    "railways:track_byg_jacaranda",
-    "railways:track_byg_lament",
-    "railways:track_byg_mahogany",
-    "railways:track_byg_maple",
-    "railways:track_byg_nightshade",
-    "railways:track_byg_palm",
-    "railways:track_byg_pine",
-    "railways:track_byg_rainbow_eucalyptus",
-    "railways:track_byg_redwood",
-    "railways:track_byg_skyris",
-    "railways:track_byg_sythian",
-    "railways:track_byg_white_mangrove",
-    "railways:track_byg_willow",
-    "railways:track_byg_witch_hazel",
-    "railways:track_byg_zelkova",
-    "railways:track_blue_skies_bluebright",
-    "railways:track_blue_skies_cherry",
-    "railways:track_blue_skies_dusk",
-    "railways:track_blue_skies_frostbright",
-    "railways:track_blue_skies_lunar",
-    "railways:track_blue_skies_maple",
-    "railways:track_blue_skies_starlit",
-    "railways:track_twilightforest_canopy",
-    "railways:track_twilightforest_darkwood",
-    "railways:track_twilightforest_mangrove",
-    "railways:track_twilightforest_minewood",
-    "railways:track_twilightforest_sortingwood",
-    "railways:track_twilightforest_timewood",
-    "railways:track_twilightforest_transwood",
-    "railways:track_twilightforest_twilight_oak",
-    "railways:track_biomesoplenty_cherry",
-    "railways:track_biomesoplenty_dead",
-    "railways:track_biomesoplenty_fir",
-    "railways:track_biomesoplenty_hellbark",
-    "railways:track_biomesoplenty_jacaranda",
-    "railways:track_biomesoplenty_magic",
-    "railways:track_biomesoplenty_mahogany",
-    "railways:track_biomesoplenty_palm",
-    "railways:track_biomesoplenty_redwood",
-    "railways:track_biomesoplenty_umbran",
-    "railways:track_biomesoplenty_willow"
+    {
+      "id": "railways:track_hexcasting_edified",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_aspen",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_baobab",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_blue_enchanted",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_bulbis",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_cherry",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_cika",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_cypress",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_ebony",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_embur",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_ether",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_fir",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_green_enchanted",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_holly",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_imparius",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_jacaranda",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_lament",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_mahogany",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_maple",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_nightshade",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_palm",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_pine",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_rainbow_eucalyptus",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_redwood",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_skyris",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_sythian",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_white_mangrove",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_willow",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_witch_hazel",
+      "required": false
+    },
+    {
+      "id": "railways:track_byg_zelkova",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_bluebright",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_cherry",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_dusk",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_frostbright",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_lunar",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_maple",
+      "required": false
+    },
+    {
+      "id": "railways:track_blue_skies_starlit",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_canopy",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_darkwood",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_mangrove",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_minewood",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_sortingwood",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_timewood",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_transwood",
+      "required": false
+    },
+    {
+      "id": "railways:track_twilightforest_twilight_oak",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_cherry",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_dead",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_fir",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_hellbark",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_jacaranda",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_magic",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_mahogany",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_palm",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_redwood",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_umbran",
+      "required": false
+    },
+    {
+      "id": "railways:track_biomesoplenty_willow",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_acacia.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_acacia.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_cherry.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_dead.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_dead.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_fir.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_fir.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_hellbark.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_hellbark.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_jacaranda.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_jacaranda.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_magic.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_magic.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_mahogany.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_mahogany.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_umbran.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_umbran.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_willow.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_willow.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_birch.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_birch.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_bluebright.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_bluebright.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_cherry.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_dusk.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_dusk.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_frostbright.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_frostbright.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_lunar.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_lunar.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_maple.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_maple.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_starlit.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_starlit.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_aspen.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_aspen.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_baobab.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_baobab.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_blue_enchanted.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_blue_enchanted.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_bulbis.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_bulbis.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cherry.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cika.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cika.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cypress.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cypress.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ebony.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ebony.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_embur.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_embur.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ether.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ether.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_fir.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_fir.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_green_enchanted.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_green_enchanted.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_holly.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_holly.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_imparius.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_imparius.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_jacaranda.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_jacaranda.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_lament.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_lament.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_mahogany.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_mahogany.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_maple.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_maple.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_nightshade.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_nightshade.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_palm.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_palm.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_pine.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_pine.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_rainbow_eucalyptus.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_rainbow_eucalyptus.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_redwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_redwood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_skyris.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_skyris.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_sythian.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_sythian.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_white_mangrove.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_white_mangrove.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_willow.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_willow.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_witch_hazel.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_witch_hazel.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_zelkova.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_zelkova.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_dark_oak.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_dark_oak.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_ender.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_ender.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_hexcasting_edified.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_hexcasting_edified.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_jungle.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_jungle.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_mangrove.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_mangrove.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_oak.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_oak.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_spruce.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_spruce.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_tieless.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_tieless.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_canopy.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_canopy.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_darkwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_darkwood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_mangrove.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_mangrove.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_minewood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_minewood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_sortingwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_sortingwood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_timewood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_timewood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_transwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_transwood.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_twilight_oak.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_twilight_oak.json
@@ -18,10 +18,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],
@@ -39,10 +39,10 @@
         },
         [
           {
-            "tag": "c:iron_nuggets"
+            "tag": "railways:internal/nuggets/iron_nuggets"
           },
           {
-            "tag": "c:zinc_nuggets"
+            "tag": "railways:internal/nuggets/zinc_nuggets"
           }
         ]
       ],

--- a/common/src/main/java/com/railwayteam/railways/base/data/recipe/RailwaysSequencedAssemblyRecipeGen.java
+++ b/common/src/main/java/com/railwayteam/railways/base/data/recipe/RailwaysSequencedAssemblyRecipeGen.java
@@ -72,7 +72,9 @@ public abstract class RailwaysSequencedAssemblyRecipeGen extends RailwaysRecipeP
       if (railsIngredient.values.length == 2 && Arrays.stream(railsIngredient.values).allMatch((value) -> {
         return value instanceof Ingredient.TagValue tagValue
             && (tagValue.tag.equals(AllTags.forgeItemTag("nuggets/iron"))
-                || tagValue.tag.equals(AllTags.forgeItemTag("nuggets/zinc")));
+                || tagValue.tag.equals(AllTags.forgeItemTag("nuggets/zinc"))
+                || tagValue.tag.equals(AllTags.forgeItemTag("iron_nuggets"))
+                || tagValue.tag.equals(AllTags.forgeItemTag("zinc_nuggets"))); // TODO wait until create fabric merge such difference between 1.18 and 1.19
       })) {
         railsIngredient = Ingredient.fromValues(Stream.of(
             TagValueAccessor.createTagValue(Ingredients.ironNugget()),

--- a/common/src/main/java/com/railwayteam/railways/compat/tracks/TrackCompatUtils.java
+++ b/common/src/main/java/com/railwayteam/railways/compat/tracks/TrackCompatUtils.java
@@ -19,6 +19,7 @@ import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import com.tterrag.registrate.util.nullness.NonNullConsumer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -72,7 +73,8 @@ public abstract class TrackCompatUtils {
         String name = "track_" + owningMod + "_" + material.resourceName();
 
         addOptionalTag(Railways.asResource(name), AllTags.AllBlockTags.TRACKS.tag,
-            CommonTags.RELOCATION_NOT_SUPPORTED.forge, CommonTags.RELOCATION_NOT_SUPPORTED.fabric);
+            CommonTags.RELOCATION_NOT_SUPPORTED.forge, CommonTags.RELOCATION_NOT_SUPPORTED.fabric,
+                BlockTags.MINEABLE_WITH_PICKAXE); // pickaxe-mineable tag is moved here as Registrate cannot add optional tag in BlockBuilder
         if (material.trackType != CRTrackMaterials.CRTrackType.MONORAIL)
             addOptionalTag(Railways.asResource(name), AllTags.AllBlockTags.GIRDABLE_TRACKS.tag);
 
@@ -84,7 +86,6 @@ public abstract class TrackCompatUtils {
                 .sound(SoundType.METAL)
                 .noOcclusion())
             .addLayer(() -> RenderType::cutoutMipped)
-            .transform(pickaxeOnly())
             .blockstate(blockstateGen)
             .lang(material.langName + " Train Track")
             .onRegister(onRegister)


### PR DESCRIPTION
This fixes track assembly recipe not usable in forge 1.19 because Create Fabric for 1.19 has changed #nuggets/iron and #nuggets/zinc tags to #iron_nuggets and #zinc_nuggets (or correcting them?), and the datagen failed to match them and replace them with Railways internal tag. Note that this fix simply add two more tags in predicate, and old tags should be removed once Create Fabric for 1.18 has followed up tag changes.
This also fixes mod-compat tracks breaking pickaxe mineable tags because they don't get registered.