### PR TITLE
1.19/dev Mod compat - Missing Forge condition (only Forge railways:sequenced_assembly recipes modifed)

### DIFF
--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_cherry.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_cherry"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_dead.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_dead.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_dead"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_fir.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_fir.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_fir"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_hellbark.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_hellbark.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_hellbark"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_jacaranda.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_jacaranda.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_jacaranda"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_magic.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_magic.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_magic"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_mahogany.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_mahogany.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_mahogany"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_palm"
-  }
+  }  
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_palm.json
@@ -73,7 +73,7 @@
   "conditions": [
     {
       "type": "forge:mod_loaded",
-      "modid": "create"
+      "modid": "biomesoplenty"
     }
   ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_redwood"
-  }
+  }  
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_redwood.json
@@ -73,7 +73,7 @@
   "conditions": [
     {
       "type": "forge:mod_loaded",
-      "modid": "create"
+      "modid": "biomesoplenty"
     }
   ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_umbran.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_umbran.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_umbran"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_willow.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_biomesoplenty_willow.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_biomesoplenty_willow"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "biomesoplenty"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_bluebright.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_bluebright.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_bluebright"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_cherry.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_cherry"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_dusk.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_dusk.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_dusk"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_frostbright.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_frostbright.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_frostbright"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_lunar.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_lunar.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_lunar"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_maple.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_maple.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_maple"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_starlit.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_blue_skies_starlit.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_blue_skies_starlit"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "blue_skies"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_aspen.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_aspen.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_aspen"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_baobab.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_baobab.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_baobab"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_blue_enchanted.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_blue_enchanted.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_blue_enchanted"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_bulbis.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_bulbis.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_bulbis"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cherry.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cherry.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_cherry"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cika.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cika.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_cika"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cypress.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_cypress.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_cypress"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ebony.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ebony.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_ebony"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_embur.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_embur.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_embur"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ether.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_ether.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_ether"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_fir.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_fir.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_fir"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_green_enchanted.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_green_enchanted.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_green_enchanted"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_holly.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_holly.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_holly"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_imparius.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_imparius.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_imparius"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_jacaranda.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_jacaranda.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_jacaranda"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_lament.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_lament.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_lament"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_mahogany.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_mahogany.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_mahogany"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_maple.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_maple.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_maple"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_nightshade.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_nightshade.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_nightshade"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_palm.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_palm.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_palm"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_pine.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_pine.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_pine"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_rainbow_eucalyptus.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_rainbow_eucalyptus.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_rainbow_eucalyptus"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_redwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_redwood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_redwood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_skyris.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_skyris.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_skyris"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_sythian.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_sythian.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_sythian"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_white_mangrove.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_white_mangrove.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_white_mangrove"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_willow.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_willow.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_willow"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_witch_hazel.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_witch_hazel.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_witch_hazel"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_zelkova.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_byg_zelkova.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_byg_zelkova"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_hexcasting_edified.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_hexcasting_edified.json
@@ -68,5 +68,12 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_hexcasting_edified"
-  }
+  } 
+  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "hexcasting"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_canopy.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_canopy.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_canopy"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_darkwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_darkwood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_darkwood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_mangrove.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_mangrove.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_mangrove"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_minewood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_minewood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_minewood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_sortingwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_sortingwood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_sortingwood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_timewood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_timewood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_timewood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_transwood.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_transwood.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_transwood"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }

--- a/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_twilight_oak.json
+++ b/common/src/generated/resources/data/railways/recipes/sequenced_assembly/track_twilightforest_twilight_oak.json
@@ -68,5 +68,11 @@
   ],
   "transitionalItem": {
     "item": "railways:track_incomplete_twilightforest_twilight_oak"
-  }
+  }  ,
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "twilightforest"
+    }
+  ]
 }


### PR DESCRIPTION
Warning from log (same for all other recipes) :
[21:40:36] [Render thread/WARN]: Failed to parse recipe 'railways:sequenced_assembly/track_byg_rainbow_eucalyptus[create:sequenced_assembly]'! Falling back to vanilla: com.google.gson.JsonSyntaxException: Unknown item 'byg:rainbow_eucalyptus_slab'

to fix this only need to add this :
  "conditions": [
    {
      "type": "forge:mod_loaded",
      "modid": "modid"
    }
  ]