### PR TITLE
extra mod menu eye candy

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -50,5 +50,17 @@
   "suggests": {
     "hexcasting": "*",
     "voicechat": ">=${minecraft_version}-${voicechat_api_version}"
+  },
+  "custom": {
+    "modmenu": {
+      "parent": {
+        "id": "create"
+      },
+      "links": {
+        "Modrinth": "https://modrinth.com/mod/create-steam-n-rails",
+        "CurseForge": "https://curseforge.com/minecraft/mc-mods/create-steam-n-rails",
+        "Discord": "https://discord.gg/md78MGbEfK"
+      }
+    }
   }
 }


### PR DESCRIPTION
snr now shows up under create (since it's a create addon):
<img width="402" alt="image" src="https://github.com/Layers-of-Railways/Railway/assets/98863820/5718fe67-7438-423b-bf18-69901765aa1f">

I also added some cool links:
<img width="454" alt="image" src="https://github.com/Layers-of-Railways/Railway/assets/98863820/70e4f4ef-aa0e-495e-9fe2-4cfcadb847a5">
