### PR TITLE
fixed the boiler placement helper direction

### DIFF
--- a/common/src/main/java/com/railwayteam/railways/content/boiler/BoilerBlock.java
+++ b/common/src/main/java/com/railwayteam/railways/content/boiler/BoilerBlock.java
@@ -270,6 +270,7 @@ public class BoilerBlock extends Block implements IWrenchable, IForceRenderingSo
 
             List<Direction> directions = IPlacementHelper.orderedByDistance(pos, ray.getLocation(), dir -> dir.getAxis() == axisFunction.apply(state));
             for (Direction dir : directions) {
+                dir = dir.getOpposite();
                 int range = AllConfigs.server().equipment.placementAssistRange.get();
                 if (player != null) {
                     AttributeInstance reach = player.getAttribute(getAttribute());


### PR DESCRIPTION
makes the boiler placement helper go in the same direction as shafts, copycat steps/panels, gantry shafts, and other blocks that use the placement helper