### PR TITLE
Fix #425: trains burned liquid fuels excessively quick

### DIFF
--- a/common/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelTrainHandler.java
+++ b/common/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelTrainHandler.java
@@ -25,9 +25,9 @@ public class LiquidFuelTrainHandler {
         } else {
             int bucketBurnTime = PlatformAbstractionHelper.getBurnTime(fluid.getBucket());
 
-            // Divide burnTime by 100 to get burnTime for 1/10th of a bucket and then by divide by 4,
+            // Divide burnTime by 10 to get burnTime for 1/10th of a bucket and then by divide by 4,
             // so it isn't so strong
-            burnTime = (bucketBurnTime / 100) / 4;
+            burnTime = (bucketBurnTime / 10) / 4;
         }
 
         return burnTime;

--- a/common/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelType.java
+++ b/common/src/main/java/com/railwayteam/railways/content/fuel/LiquidFuelType.java
@@ -20,7 +20,7 @@ public class LiquidFuelType {
     private final List<Supplier<Fluid>> fluids = new ArrayList<>();
     private final List<Supplier<TagKey<Fluid>>> fluidTags = new ArrayList<>();
 
-    private int fuelTicks = 40;
+    private int fuelTicks = 400;
     private boolean invalid = false;
 
     public LiquidFuelType() { }


### PR DESCRIPTION
Trains burned through fluid fuels 40x faster than their bucketed counterparts, which made fuel tanks impractical for long-distance railway systems.