### PR TITLE
Deployer Train Renaming

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Steam 'n' Rails 1.7.0
 <!--this is the next unreleased version-->
 Fixes
 - Conductors can once again drive trains backwards via redstone link (pr#649 by konek101)
+- Deployers can copy train names to/from nametags (pr#576 by SofieBrink)
 ------------------------------------------------------
 Steam 'n' Rails 1.6.9
 ------------------------------------------------------

--- a/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
+++ b/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
@@ -18,9 +18,6 @@
 
 package com.railwayteam.railways.mixin;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.railwayteam.railways.Railways;
 import com.railwayteam.railways.config.CRConfigs;
 import com.railwayteam.railways.content.conductor.ConductorEntity;
 import com.railwayteam.railways.mixin_interfaces.ICarriageConductors;
@@ -54,6 +51,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.NameTagItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -266,58 +264,29 @@ public abstract class MixinStationBlock {
             .addFreshEntity(itemEntity);
     }
 
-//    @Inject(method = "use"
-//          , at = @At(value = "INVOKE"
-//                   , target = "Lcom/simibubi/create/content/trains/station/StationBlock;onBlockEntityUse(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Ljava/util/function/Function;)Lnet/minecraft/world/InteractionResult;"
-//                   , ordinal = 1)
-//          , cancellable = true
-//          , remap = false)
     @Inject(method = "use", at = @At("HEAD"), cancellable = true, remap = true)
     private void deployersNameTag(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit, CallbackInfoReturnable<InteractionResult> cir) {
         ItemStack itemInHand = pPlayer.getItemInHand(pHand);
-        if (!pLevel.isClientSide
-         && pPlayer instanceof DeployerFakePlayer deployerFakePlayer
-         && pLevel.getBlockEntity(pPos) instanceof StationBlockEntity stationBe
-         && itemInHand.getItem() instanceof net.minecraft.world.item.NameTagItem)
-        {
+        if (!pLevel.isClientSide && pPlayer instanceof DeployerFakePlayer
+            && pLevel.getBlockEntity(pPos) instanceof StationBlockEntity stationBe
+            && itemInHand.getItem() instanceof NameTagItem
+        ) {
             cir.setReturnValue(InteractionResult.CONSUME);
             GlobalStation station = stationBe.getStation();
-            if (station != null && station.getPresentTrain() != null) {
-                Train train = station.getPresentTrain();
-                if (itemInHand.hasTag() && itemInHand.getTag().contains("display")) {
-                    CompoundTag displayTag = itemInHand.getTag().getCompound("display");
-                    if (displayTag.contains("Name")) {
-                        // Set the train name
-                        JsonObject json = JsonParser.parseString(displayTag.getString("Name")).getAsJsonObject();
-                        String newName = json.get("text").getAsString();
+            if (station == null || station.getPresentTrain() == null) return;
 
-                        if (train.name.getString().equals(newName)) return;
+            Train train = station.getPresentTrain();
+            if (itemInHand.hasCustomHoverName()) { // Set the train name
+                String newName = itemInHand.getHoverName().getString();
+                if (train.name.getString().equals(newName)) return;
 
-                        if (pLevel.getServer().isDedicatedServer()) {
-                            train.name = Components.literal(newName);
-                            AllPackets.getChannel()
-                                      .sendToClientsInServer(new TrainEditPacket
-                                                                .TrainEditReturnPacket(train.id, newName, train.icon.getId())
-                                                           , pLevel.getServer());
-                        }
-                        else
-                            AllPackets.getChannel()
-                                      .sendToServer(new TrainEditPacket(train.id, newName, train.icon.getId()));
-                    }
-                }
-                else {
-                    // Get the trains name and put it on the nametag
-                    JsonObject displayNameJson = new JsonObject();
-                    displayNameJson.addProperty("text", train.name.getString());
-
-                    CompoundTag tag = itemInHand.getOrCreateTag();
-                    CompoundTag displayTag = tag.contains("display", 10)
-                                           ? tag.getCompound("display")
-                                           : new CompoundTag();
-                    displayTag.putString("Name", displayNameJson.toString());
-                    tag.put("display", displayTag);
-                    itemInHand.setTag(tag);
-                }
+                train.name = Components.literal(newName);
+                AllPackets.getChannel().sendToClientsInServer(
+                    new TrainEditPacket.TrainEditReturnPacket(train.id, newName, train.icon.getId()),
+                    pLevel.getServer()
+                );
+            } else { // Get the train's name and put it on the nametag
+                itemInHand.setHoverName(Components.literal(train.name.getString()));
             }
         }
     }

--- a/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
+++ b/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
@@ -290,6 +290,9 @@ public abstract class MixinStationBlock {
                         // Set the train name
                         JsonObject json = JsonParser.parseString(displayTag.getString("Name")).getAsJsonObject();
                         String newName = json.get("text").getAsString();
+
+                        if (train.name.getString().equals(newName)) return;
+
                         if (pLevel.getServer().isDedicatedServer()) {
                             train.name = Components.literal(newName);
                             AllPackets.getChannel()

--- a/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
+++ b/common/src/main/java/com/railwayteam/railways/mixin/MixinStationBlock.java
@@ -18,12 +18,15 @@
 
 package com.railwayteam.railways.mixin;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.railwayteam.railways.Railways;
 import com.railwayteam.railways.config.CRConfigs;
 import com.railwayteam.railways.content.conductor.ConductorEntity;
 import com.railwayteam.railways.mixin_interfaces.ICarriageConductors;
 import com.railwayteam.railways.registry.CRBlocks;
 import com.railwayteam.railways.registry.CREntities;
+import com.simibubi.create.AllPackets;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.kinetics.deployer.DeployerFakePlayer;
 import com.simibubi.create.content.trains.entity.Carriage;
@@ -35,6 +38,8 @@ import com.simibubi.create.content.trains.schedule.destination.DestinationInstru
 import com.simibubi.create.content.trains.station.GlobalStation;
 import com.simibubi.create.content.trains.station.StationBlock;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
+import com.simibubi.create.content.trains.station.TrainEditPacket;
+import com.simibubi.create.foundation.utility.Components;
 import com.simibubi.create.foundation.utility.VecHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -259,5 +264,58 @@ public abstract class MixinStationBlock {
         itemEntity.setDeltaMovement(Vec3.ZERO);
         te.getLevel()
             .addFreshEntity(itemEntity);
+    }
+
+//    @Inject(method = "use"
+//          , at = @At(value = "INVOKE"
+//                   , target = "Lcom/simibubi/create/content/trains/station/StationBlock;onBlockEntityUse(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;Ljava/util/function/Function;)Lnet/minecraft/world/InteractionResult;"
+//                   , ordinal = 1)
+//          , cancellable = true
+//          , remap = false)
+    @Inject(method = "use", at = @At("HEAD"), cancellable = true, remap = true)
+    private void deployersNameTag(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand, BlockHitResult pHit, CallbackInfoReturnable<InteractionResult> cir) {
+        ItemStack itemInHand = pPlayer.getItemInHand(pHand);
+        if (!pLevel.isClientSide
+         && pPlayer instanceof DeployerFakePlayer deployerFakePlayer
+         && pLevel.getBlockEntity(pPos) instanceof StationBlockEntity stationBe
+         && itemInHand.getItem() instanceof net.minecraft.world.item.NameTagItem)
+        {
+            cir.setReturnValue(InteractionResult.CONSUME);
+            GlobalStation station = stationBe.getStation();
+            if (station != null && station.getPresentTrain() != null) {
+                Train train = station.getPresentTrain();
+                if (itemInHand.hasTag() && itemInHand.getTag().contains("display")) {
+                    CompoundTag displayTag = itemInHand.getTag().getCompound("display");
+                    if (displayTag.contains("Name")) {
+                        // Set the train name
+                        JsonObject json = JsonParser.parseString(displayTag.getString("Name")).getAsJsonObject();
+                        String newName = json.get("text").getAsString();
+                        if (pLevel.getServer().isDedicatedServer()) {
+                            train.name = Components.literal(newName);
+                            AllPackets.getChannel()
+                                      .sendToClientsInServer(new TrainEditPacket
+                                                                .TrainEditReturnPacket(train.id, newName, train.icon.getId())
+                                                           , pLevel.getServer());
+                        }
+                        else
+                            AllPackets.getChannel()
+                                      .sendToServer(new TrainEditPacket(train.id, newName, train.icon.getId()));
+                    }
+                }
+                else {
+                    // Get the trains name and put it on the nametag
+                    JsonObject displayNameJson = new JsonObject();
+                    displayNameJson.addProperty("text", train.name.getString());
+
+                    CompoundTag tag = itemInHand.getOrCreateTag();
+                    CompoundTag displayTag = tag.contains("display", 10)
+                                           ? tag.getCompound("display")
+                                           : new CompoundTag();
+                    displayTag.putString("Name", displayNameJson.toString());
+                    tag.put("display", displayTag);
+                    itemInHand.setTag(tag);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #575 (Partially)

This pull request partially resolves issue 575 for automatic renaming of trains.
It allows deployers to copy a train's name when holding a blank nametag and write to the train's name when the nametag held by the deployer has a custom name. 

I've elected not to add the washing recipe as i'm not convinced this is the best solution balance wise. I'm open to suggestions as to how this could be done better. But for now it can very easily be achieved with a simple datapack.

There's also a few issues with the pull request itself. 
Mainly that the mixin injection for the deployersNameTag method is currently injecting at `HEAD` instead of at the second use of the `onBlockEntityUse` method call from the base. this is because this mixin injection didn't seem to work with the built jar that gradle outputs, even though it works perfectly with the built in client that can be launched through the IDE.
Help is welcome.

I'd be happy to make any adjustments if needed and wouldn't be disappointed or angry if this ends up not getting merged as i didn't wait for an official go to start coding this feature. 
Worst case scenario, I had some fun coding the feature and learnt some new skills.