### PR TITLE
Fix fuel tanks and fuel storage interface (#638)

### DIFF
--- a/common/src/main/java/com/railwayteam/railways/mixin/MixinContraption.java
+++ b/common/src/main/java/com/railwayteam/railways/mixin/MixinContraption.java
@@ -38,7 +38,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Contraption.class)
 public abstract class MixinContraption implements IContraptionFuel {
-    @Shadow(remap = false) protected MountedStorageManager storage;
+
+    @Shadow public abstract MountedStorageManager getStorage();
 
     @Inject(method = "removeBlocksFromWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;removeBlockEntity(Lnet/minecraft/core/BlockPos;)V"))
     private void applyPreTransformCallback(Level world, BlockPos offset, CallbackInfo ci, @Local(name="add") BlockPos add) {
@@ -56,6 +57,6 @@ public abstract class MixinContraption implements IContraptionFuel {
 
     @Override
     public MountedFluidStorageWrapper railways$getFluidFuels() {
-        return ((IFuelInventory) storage).railways$getFluidFuels();
+        return ((IFuelInventory) getStorage()).railways$getFluidFuels();
     }
 }

--- a/fabric/src/main/java/com/railwayteam/railways/content/fuel/psi/PortableFuelInterfaceBlockEntity.java
+++ b/fabric/src/main/java/com/railwayteam/railways/content/fuel/psi/PortableFuelInterfaceBlockEntity.java
@@ -19,6 +19,7 @@
 package com.railwayteam.railways.content.fuel.psi;
 
 import com.railwayteam.railways.mixin_interfaces.IContraptionFuel;
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageWrapper;
 import com.simibubi.create.content.contraptions.Contraption;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import com.simibubi.create.foundation.utility.fabric.ListeningStorageView;
@@ -49,7 +50,8 @@ public class PortableFuelInterfaceBlockEntity extends PortableStorageInterfaceBl
 
     @Override
     public void startTransferringTo(Contraption contraption, float distance) {
-        capability.setWrapped(((IContraptionFuel) contraption).railways$getFluidFuels());
+        MountedFluidStorageWrapper fuels = ((IContraptionFuel) contraption).railways$getFluidFuels();
+        capability.setWrapped(fuels != null ? fuels : Storage.empty());
         super.startTransferringTo(contraption, distance);
     }
 

--- a/fabric/src/main/java/com/railwayteam/railways/content/fuel/tank/FuelTankMovementBehavior.java
+++ b/fabric/src/main/java/com/railwayteam/railways/content/fuel/tank/FuelTankMovementBehavior.java
@@ -1,0 +1,41 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2025 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.content.fuel.tank;
+
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+public class FuelTankMovementBehavior implements MovementBehaviour {
+    @Override
+    public boolean mustTickWhileDisabled() {
+        return true;
+    }
+
+    @Override
+    public void tick(MovementContext context) {
+        if(!context.world.isClientSide)
+            return;
+
+        BlockEntity be = context.contraption.presentBlockEntities.get(context.localPos);
+        if(be instanceof FuelTankBlockEntity fuelTank) {
+            fuelTank.getFluidLevel().tickChaser();
+        }
+    }
+}

--- a/fabric/src/main/java/com/railwayteam/railways/registry/fabric/CRBlocksImpl.java
+++ b/fabric/src/main/java/com/railwayteam/railways/registry/fabric/CRBlocksImpl.java
@@ -20,7 +20,11 @@ package com.railwayteam.railways.registry.fabric;
 
 import com.railwayteam.railways.Railways;
 import com.railwayteam.railways.content.fuel.psi.PortableFuelInterfaceBlock;
-import com.railwayteam.railways.content.fuel.tank.*;
+import com.railwayteam.railways.content.fuel.tank.FuelTankBlock;
+import com.railwayteam.railways.content.fuel.tank.FuelTankGenerator;
+import com.railwayteam.railways.content.fuel.tank.FuelTankItem;
+import com.railwayteam.railways.content.fuel.tank.FuelTankModel;
+import com.railwayteam.railways.content.fuel.tank.FuelTankMovementBehavior;
 import com.simibubi.create.AllTags;
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageType;

--- a/fabric/src/main/java/com/railwayteam/railways/registry/fabric/CRBlocksImpl.java
+++ b/fabric/src/main/java/com/railwayteam/railways/registry/fabric/CRBlocksImpl.java
@@ -20,11 +20,9 @@ package com.railwayteam.railways.registry.fabric;
 
 import com.railwayteam.railways.Railways;
 import com.railwayteam.railways.content.fuel.psi.PortableFuelInterfaceBlock;
-import com.railwayteam.railways.content.fuel.tank.FuelTankBlock;
-import com.railwayteam.railways.content.fuel.tank.FuelTankGenerator;
-import com.railwayteam.railways.content.fuel.tank.FuelTankItem;
-import com.railwayteam.railways.content.fuel.tank.FuelTankModel;
+import com.railwayteam.railways.content.fuel.tank.*;
 import com.simibubi.create.AllTags;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageType;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceMovement;
 import com.simibubi.create.foundation.data.AssetLookup;
@@ -51,6 +49,7 @@ public class CRBlocksImpl {
             .blockstate(new FuelTankGenerator()::generate)
             .onRegister(CreateRegistrate.blockModel(() -> FuelTankModel::standard))
             .transform(MountedFluidStorageType.mountedFluidStorage(CRMountedStorageTypesImpl.FUEL_TANK))
+            .onRegister(MovementBehaviour.movementBehaviour(new FuelTankMovementBehavior()))
             .addLayer(() -> RenderType::cutoutMipped)
             .item(FuelTankItem::new)
             .model(AssetLookup.customBlockItemModel("_", "block_single_window"))

--- a/forge/src/main/java/com/railwayteam/railways/content/fuel/psi/PortableFuelInterfaceBlockEntity.java
+++ b/forge/src/main/java/com/railwayteam/railways/content/fuel/psi/PortableFuelInterfaceBlockEntity.java
@@ -19,6 +19,7 @@
 package com.railwayteam.railways.content.fuel.psi;
 
 import com.railwayteam.railways.mixin_interfaces.IContraptionFuel;
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageWrapper;
 import com.simibubi.create.content.contraptions.Contraption;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import net.minecraft.core.BlockPos;
@@ -43,7 +44,10 @@ public class PortableFuelInterfaceBlockEntity extends PortableStorageInterfaceBl
     @Override
     public void startTransferringTo(Contraption contraption, float distance) {
         LazyOptional<IFluidHandler> oldcap = capability;
-        capability = LazyOptional.of(() -> new InterfaceFluidHandler(((IContraptionFuel) contraption).railways$getFluidFuels()));
+        capability = LazyOptional.of(() -> {
+            MountedFluidStorageWrapper fuels = ((IContraptionFuel) contraption).railways$getFluidFuels();
+            return new InterfaceFluidHandler(fuels != null ? fuels : new FluidTank(0));
+        });
         oldcap.invalidate();
         super.startTransferringTo(contraption, distance);
     }

--- a/forge/src/main/java/com/railwayteam/railways/content/fuel/tank/FuelTankMovementBehavior.java
+++ b/forge/src/main/java/com/railwayteam/railways/content/fuel/tank/FuelTankMovementBehavior.java
@@ -1,0 +1,41 @@
+/*
+ * Steam 'n' Rails
+ * Copyright (c) 2025 The Railways Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.railwayteam.railways.content.fuel.tank;
+
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+public class FuelTankMovementBehavior implements MovementBehaviour {
+    @Override
+    public boolean mustTickWhileDisabled() {
+        return true;
+    }
+
+    @Override
+    public void tick(MovementContext context) {
+        if(!context.world.isClientSide)
+            return;
+
+        BlockEntity be = context.contraption.presentBlockEntities.get(context.localPos);
+        if(be instanceof FuelTankBlockEntity fuelTank) {
+            fuelTank.getFluidLevel().tickChaser();
+        }
+    }
+}

--- a/forge/src/main/java/com/railwayteam/railways/registry/forge/CRBlocksImpl.java
+++ b/forge/src/main/java/com/railwayteam/railways/registry/forge/CRBlocksImpl.java
@@ -23,7 +23,9 @@ import com.railwayteam.railways.content.fuel.psi.PortableFuelInterfaceBlock;
 import com.railwayteam.railways.content.fuel.tank.FuelTankBlock;
 import com.railwayteam.railways.content.fuel.tank.FuelTankItem;
 import com.railwayteam.railways.content.fuel.tank.FuelTankModel;
+import com.railwayteam.railways.content.fuel.tank.FuelTankMovementBehavior;
 import com.simibubi.create.AllTags;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageType;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceMovement;
 import com.simibubi.create.foundation.data.AssetLookup;
@@ -51,6 +53,7 @@ public class CRBlocksImpl {
             //.blockstate(new FuelTankGenerator()::generate) Handled by fabric subproject
             .onRegister(CreateRegistrate.blockModel(() -> FuelTankModel::standard))
             .transform(MountedFluidStorageType.mountedFluidStorage(CRMountedStorageTypesImpl.FUEL_TANK))
+            .onRegister(MovementBehaviour.movementBehaviour(new FuelTankMovementBehavior()))
             .addLayer(() -> RenderType::cutoutMipped)
             .item(FuelTankItem::new)
             .model(AssetLookup.customBlockItemModel("_", "block_single_window"))


### PR DESCRIPTION
This fixes issue #638, as well as adds the movement behavior for fuel tanks to render their fluid level on contraptions.

Forge has been tested, Fabric has largely not. However, I did apply the same fixes to both loaders.