### PR TITLE
Add driving backwards via redstone link

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -346,6 +346,7 @@ tasks.create("railwaysPublish") {
 fun Project.setupRepositories() {
     repositories {
         mavenCentral()
+        maven("https://modmaven.dev/")
         maven("https://maven.shedaniel.me/") // Cloth Config, REI
         maven("https://maven.blamejared.com/") // JEI, Hex Casting
         exclusiveMaven("https://maven.parchmentmc.org", "org.parchmentmc.data") // Parchment mappings

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -346,7 +346,7 @@ tasks.create("railwaysPublish") {
 fun Project.setupRepositories() {
     repositories {
         mavenCentral()
-        maven("https://modmaven.dev/")
+        maven("https://modmaven.dev/") // flywheel fabric
         maven("https://maven.shedaniel.me/") // Cloth Config, REI
         maven("https://maven.blamejared.com/") // JEI, Hex Casting
         exclusiveMaven("https://maven.parchmentmc.org", "org.parchmentmc.data") // Parchment mappings

--- a/common/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
+++ b/common/src/main/java/com/railwayteam/railways/content/conductor/ConductorEntity.java
@@ -763,6 +763,16 @@ public class ConductorEntity extends AbstractGolem {
     return forwardListener.receivedStrength;
   }
 
+  public int getThrottle() {
+    int forwardStrength;
+    int backwardStrength;
+    if (forwardListener == null) forwardStrength = 0;
+    else forwardStrength = forwardListener.receivedStrength;
+    if (backwardListener == null) backwardStrength = 0;
+    else backwardStrength = backwardListener.receivedStrength;
+    return forwardStrength - backwardStrength;
+  }
+
   private List<ItemStack> getHeldSchedules() {
     if (heldSchedules == null) {
       heldSchedules = new ArrayList<>();
@@ -1261,17 +1271,29 @@ public class ConductorEntity extends AbstractGolem {
           return;
         }
         Set<Integer> controls = getControls();
-        if (reverseControlsPos != null && controls.contains(1) && !controls.contains(0)) { // go backwards quickly
-          controls.remove(1);
-          controls.add(0);
+
+        boolean isSprintKeyPressed = controls.remove(5);
+        Set<Integer> fakeControls = new HashSet<>(controls);
+        int throttle = conductor.getThrottle();
+        //remove old controls
+        fakeControls.remove(0); // forward
+        fakeControls.remove(1); // backward
+        //add new controls depending on the signal difference of the throttle
+        if (throttle > 0) {
+          fakeControls.add(0);
+        } else if (throttle < 0) {
+          fakeControls.add(1);
+        }
+        if (reverseControlsPos != null && fakeControls.contains(1)) { // go backwards quickly
+          fakeControls.remove(1);
+          fakeControls.add(0);
           /*boolean left = controls.remove(2);
           boolean right = controls.remove(3);
           if (left) controls.add(3);
           if (right) controls.add(2);*/
           controlsPos = reverseControlsPos;
         }
-        boolean isSprintKeyPressed = controls.remove(5);
-        cce.control(controlsPos, controls, conductor.fakePlayer);
+        cce.control(controlsPos, fakeControls, conductor.fakePlayer);
 
         Train train = cce.getCarriage().train;
         if (isSprintKeyPressed && honkPacketCooldown-- <= 0) {

--- a/common/src/main/java/com/railwayteam/railways/mixin/MixinCarriageContraptionEntity.java
+++ b/common/src/main/java/com/railwayteam/railways/mixin/MixinCarriageContraptionEntity.java
@@ -94,7 +94,7 @@ public abstract class MixinCarriageContraptionEntity extends OrientedContraption
     @WrapOperation(method = "control", at = @At(value = "FIELD", target = "Lcom/simibubi/create/content/trains/entity/Train;throttle:D", opcode = Opcodes.GETFIELD))
     private double conductorSpeedControl(Train instance, Operation<Double> original, BlockPos controlsLocalPos, Collection<Integer> heldControls, Player player) {
         if (player instanceof IConductorHoldingFakePlayer conductorHolder && conductorHolder.getConductor() != null) {
-            return conductorHolder.getConductor().getForwardSignalStrength() / 15.0d;
+            return Math.abs(conductorHolder.getConductor().getThrottle()) / 15.0d;
         }
         return original.call(instance);
     }


### PR DESCRIPTION
It allows to drive the conductor via redstone links backwards
plus it diffs the forewards and backwards redstone signals to get the throttle and direction

fixes #493 