### PR TITLE
Fixed medium wheel single axle standard

### DIFF
--- a/common/src/main/java/com/railwayteam/railways/content/custom_bogeys/renderer/standard/medium/MediumSingleWheelDisplay.java
+++ b/common/src/main/java/com/railwayteam/railways/content/custom_bogeys/renderer/standard/medium/MediumSingleWheelDisplay.java
@@ -56,6 +56,6 @@ public class MediumSingleWheelDisplay implements BogeyDisplay {
         wheels
             .translate(0, 12 / 16f, 0)
             .rotateXDegrees(wheelAngle)
-            .translate(0, -13 / 16f, 0);
+            .translate(0, -12 / 16f, 0);
     }
 }


### PR DESCRIPTION
Fixed a typo that causes the medium-single-axle-standard bogey to be offset down by 1 pixel causing it to clip through the tracks